### PR TITLE
Update io-package.json

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -406,7 +406,7 @@
                     {
                         "type": "state",
                         "common": {
-                            "role": "level.dimmer",
+                            "role": "level.cct.dimmer",
                             "type": "number",
                             "min": 0,
                             "max": 255,


### PR DESCRIPTION
naja war nicht ganz so sauber :/ wenn ich mit nem selector alle level.cct Objekte holen wollte haben die Dimmer gefehlt, also macht es schon Sinn, wenn sie vond er Nomenklatur her sauber in die Struktur passen.