### PR TITLE
setting of color using the RGB hex representation

### DIFF
--- a/main.js
+++ b/main.js
@@ -137,7 +137,7 @@ var adapter = utils.Adapter({
         if (state && !state.ack && states[id].native && states[id].native.channel) {
             adapter.log.debug('artnet.set', states[id].native.channel, state.val);
 
-            if (states[id].common.role === 'level.rgb') {
+            if (states[id].common.role === 'light.color.rgb') {
                 var rgb = splitColor(state.val);
                 var parts = id.split('.');
                 parts.pop();


### PR DESCRIPTION
This PR fixes setting the color of a fixture using the rgb value.
The rgb value of RGB fixtures has the role `light.color.rgb`, but was referenced by `level.rgb`.